### PR TITLE
Account for workflows that increment the version prior to publication

### DIFF
--- a/lib/denmark/plugins/metadata.rb
+++ b/lib/denmark/plugins/metadata.rb
@@ -43,11 +43,11 @@ class Denmark::Plugins::Metadata
       }
     end
 
-    if version != repo_metadata['version']
+    if SemanticPuppet::Version.parse(version) > SemanticPuppet::Version.parse(repo_metadata['version'])
       response << {
         severity: :red,
-        message: "The version released on the Forge does not match the version in the repository.",
-        explanation: "Validate that the Forge release is not compromised and is the latest released version.",
+        message: "The version released on the Forge is greater than the version in the repository.",
+        explanation: "Forge version numbers cannot be reused, so an attacker might increment the version of a pushed module to induce you to update to their compromised version. Validate that the Forge module represents the latest released version from the repository.",
       }
     end
 

--- a/lib/denmark/plugins/metadata.rb
+++ b/lib/denmark/plugins/metadata.rb
@@ -43,7 +43,10 @@ class Denmark::Plugins::Metadata
       }
     end
 
-    if SemanticPuppet::Version.parse(version) > SemanticPuppet::Version.parse(repo_metadata['version'])
+    unless (
+        [version, "v#{version}"].include? latest_tag) or
+        (SemanticPuppet::Version.parse(version) <= SemanticPuppet::Version.parse(repo_metadata['version'])
+      )
       response << {
         severity: :red,
         message: "The version released on the Forge is greater than the version in the repository.",


### PR DESCRIPTION
Some common workflows increment the version in metadata.json
immediately after publication to represent that current work is towards
the next incremental version release candidate. To compare properly, we
*should* compare the released version with the version of the latest
tag. However, I'm not convinced that we can assume that latest tag
exists consistently. I think it's likely that we'd get far more false
positives than is worth.

Instead, we check to ensure that the Forge version isn't *greater than*
the repository version. This does leave us vulnerable to a small attack
scenario in which the attacker carefully reproduces the same version
recorded in the repository and pushes that to the Forge, but I'm not
sure we can do better than this. We'll have to find other ways to flag
that behaviour.

Fixes #1
